### PR TITLE
Installation instructions

### DIFF
--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -38,6 +38,21 @@ We highly recommend users to create a separate environment for SEDR.
     python setup.py install
 
 
+Alternatively, you can install SEDR using a conda YAML file
+
+.. code-block:: python
+
+    git clone https://github.com/JinmiaoChenLab/SEDR.git
+
+    cd SEDR
+
+    conda env create -f environment.yml
+
+    conda activate SEDR
+
+    pip install .
+
+
 To use SEDR in notebook,
 
 .. code-block:: bash

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -45,3 +45,25 @@ To use SEDR in notebook,
     pip install ipykernel
 
     python -m ipykernel install --user --name=SEDR_Env
+
+
+The mclust R package is needed for running the notebooks. To install it, run the following lines in a python cell:
+
+.. code-block:: bash
+
+    import rpy2.robjects.packages as rpackages
+    from rpy2.robjects.vectors import StrVector
+
+    # set R package names
+    packnames = ('mclust',)
+
+    # import R's utility package
+    utils = rpackages.importr('utils')
+
+    utils.chooseCRANmirror(ind=1) # select the first mirror in the list
+
+    # list and install missing packages
+    packnames_to_install = [x for x in packnames if not rpackages.isinstalled(x)]
+
+    if len(packnames_to_install) > 0:
+        utils.install_packages(StrVector(packnames_to_install))

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -25,7 +25,7 @@ We highly recommend users to create a separate environment for SEDR.
 
 .. code-block:: python
 
-    conda create -n SEDR_Env python=3.11
+    conda create -n SEDR python=3.11
 
     conda activate SEDR
 
@@ -35,7 +35,7 @@ We highly recommend users to create a separate environment for SEDR.
 
     python setup.py build
 
-    python setup.py.install
+    python setup.py install
 
 
 To use SEDR in notebook,
@@ -45,4 +45,3 @@ To use SEDR in notebook,
     pip install ipykernel
 
     python -m ipykernel install --user --name=SEDR_Env
-

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,34 @@
+# -  To create a new environment:
+# conda env create -f environment.yaml
+
+# -  To update the existing environment,
+#       modify this file and run:
+# conda env update -f environment.yaml
+
+name: SEDR
+
+channels:
+  - conda-forge
+  
+dependencies:
+  - python=3.11
+  - pip
+  - ipykernel
+  - tqdm
+  - scipy
+  - numpy
+  - pandas
+  - matplotlib
+  - seaborn
+  - scikit-learn
+  - scikit-image
+  - scikit-misc
+  - anndata
+  - scanpy
+  - r-base
+  - rpy2
+  - igraph
+  - leidenalg
+  - pip:
+    - torch
+    - harmonypy


### PR DESCRIPTION
This pull request addresses installation issues encountered when setting up SEDR on a `Ubuntu 20.04.6 LTS` workstation with an Nvidia GPU and `miniconda` installed. 

After these adjustments, I successfully tested Tutorial 1, 2 and 3 and they ran smoothly.

## Changes made

- `Installation.rst` file: 
  - typos fixed:
    - updated the name of the created conda environment from `SEDR_Env` to `SEDR`, to match the name of the activated one
    - removed an extra dot in `python setup.py.install`
  - added instructions for R package `mclust` installation
  - added instructions for installation with a new `environment.yaml` file and `conda`, to simplify the setup
- `environment.yaml` file:
  - this file facilitates the installation of the dependencies, including all the packages needed for notebook execution
  - I only pinned `python=3.11` and left other package flexible